### PR TITLE
Support for MP3 and Cors

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 ```
 
-- Example
+- Example (items in [] are optional - items in <> are required)
 ```http
-  http://127.0.0.1:3000/yt?url={video_url}&q={video_quality}
+  http://127.0.0.1:3000/yt<?url={video_url}>[&q={video_quality}]<&format=mp3/mp4>
   http://127.0.0.1:3000/yt?url=https://www.youtube.com/watch?v=8IK6eLTNV1k&q=720
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "axios": "^0.21.1",
     "cheerio": "^1.0.0-rc.5",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "morgan": "^1.10.0"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -1,17 +1,21 @@
 const morgan = require('morgan');
 const express = require('express');
+const cors = require('cors');
 const app = express();
 const ytDownloader = require('./yt_downloader');
 
+app.use(cors());
+app.options('*', cors()); // to restrict this to one website only, replace the * with your website url
 app.use(morgan('dev'));
 
 app.get('/', (req, res, next) => {
-  res.send('Hello World');
+  res.send('route: /yt?url=https://youtube.com/watch?v=VIDEOURL&q=QUALITY&format=mp4/mp3');
 });
 
 app.get('/yt', async (req, res, next) => {
   try {
-    const data = await ytDownloader(req.query.url, req.query.q);
+    const videoFormat = req.query.format;
+    const data = await ytDownloader(req.query.url, (req.query.q === undefined) ? '480' : req.query.q, videoFormat); // this is a very caveman brain solution to the mp3 format, sorry.
     res.json({
       status: res.statusCode,
       result: data,

--- a/src/yt_downloader.js
+++ b/src/yt_downloader.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const cheerio = require('cheerio');
 
-module.exports = async function ytDownloader(url, videoQuality) {
+module.exports = async function ytDownloader(url, videoQuality, videoFormat) {
   const youtube = {};
   const qualityCheck = ['144', '240', '360', '480', '720', '1080'];
   let quality;
@@ -29,7 +29,7 @@ module.exports = async function ytDownloader(url, videoQuality) {
 
     // Menentukan kualitas video
     if (qualityCheck.includes(videoQuality)) {
-      quality = $(`td:contains("${videoQuality}p (.mp4)")`)
+      quality = $(`td:contains("${videoQuality}p (.${videoFormat})")`)
         .next()
         .next()
         .find('a')
@@ -45,7 +45,7 @@ module.exports = async function ytDownloader(url, videoQuality) {
     youtube.thumb = $('.thumbnail.cover img').attr('src');
 
     // Ambil size dari video
-    youtube.size = $(`td:contains("${videoQuality}p (.mp4)")`)
+    youtube.size = $(`td:contains("${videoQuality}p (.${videoFormat})")`)
       .next()
       .text()
       .trim();
@@ -58,7 +58,7 @@ module.exports = async function ytDownloader(url, videoQuality) {
     const result = await axios({
       method: 'post',
       url: 'https://www.y2mate.com/mates/convert',
-      data: `type=youtube&_id=${uniqId}&v_id=${videoId}&ajax=1&token=&ftype=mp4&fquality=${quality}`,
+      data: `type=youtube&_id=${uniqId}&v_id=${videoId}&ajax=1&token=&ftype=${videoFormat}${(videoFormat === 'mp3') ? '' : `&fquality=${quality}`}`,
     }).then((response) => response.data);
 
     // Ambil download video url


### PR DESCRIPTION
You can now download a YT video as an MP3 file. See the README.
Default quality when no quality param is given is 480.
This API can now be used with websites (Cors setup, see top of the server.js file)